### PR TITLE
Fix re-rending of login button after initial component mount

### DIFF
--- a/src/LoginButton.js
+++ b/src/LoginButton.js
@@ -9,6 +9,7 @@ class LoginButton extends React.Component {
 
         this.onSignIn = this.onSignIn.bind(this);
         this.renderGoogleLoginButton = this.renderGoogleLoginButton.bind(this);
+        this.logout = this.logout.bind(this);
     }
 
 
@@ -35,13 +36,32 @@ class LoginButton extends React.Component {
         })
     }
 
+    logout() {
+        console.log('in logout');
+        let auth2 = window.gapi && window.gapi.auth2.getAuthInstance();
+        if(auth2) {
+            auth2.signOut()
+            .then(() => {console.log('Logged out successfully')})
+            .catch(err => {console.log('Error while logging out', err)});
+        } else {
+            console.log('error while logging out');
+        }
+    }
+
     componentDidMount() {
         window.addEventListener('google-loaded', this.renderGoogleLoginButton);
+        window.gapi && this.renderGoogleLoginButton();
     }
 
     render() {
         return (
+          <div>
             <div id='my-signin2'></div>
+            <br />
+            <button style={{width: 200, height: 50, textAlign: 'center'}} onClick={this.logout}>
+                Logout
+            </button>
+          </div>
         );
     }
 


### PR DESCRIPTION
  - fix rendering of login button after initial event emit
     - on componentDidMount it listens for the even emitted after the gapi.js is loaded, but fails to load the button for subsequent component mounts [this](https://github.com/hhimanshu/google-login-with-react/compare/master...alenthomas:master#diff-c8ab5c8ff8e1d9e8a31ecc22d15ff560R53) fixes that
  - add logout option button [here](https://github.com/hhimanshu/google-login-with-react/compare/master...alenthomas:master#diff-c8ab5c8ff8e1d9e8a31ecc22d15ff560R39)